### PR TITLE
Shoe warp: fix communication

### DIFF
--- a/Stiletto.Core/HeelInfo.cs
+++ b/Stiletto.Core/HeelInfo.cs
@@ -242,7 +242,8 @@ namespace Stiletto
                 StilettoContext.NotifyHeelInfoUpdate(this);
             }
 
-            if (_shoeDirty)
+            // The animationChange case is required to work in Communication.
+            if (animationChange || _shoeDirty)
             {
                 UpdateShoeWarp();
                 _shoeDirty = false;


### PR DESCRIPTION
Upon entering a Communication scene, the shoe state was getting reset sufficiently to wipe out the changes we made to the bind poses, but not sufficiently to cause our dirty flag to get set. The animation state does get reset in this case, so we can reuse that detection to avoid breakage without having to recalculate every frame.

Let me know if you think the performance impact of this fix is problematic; I suspect it would be possible to cache the warped matrix in the same way that we cache the base matrix (but without concurrency), which would probably speed things up a bit if needed.