### PR TITLE
Add button to toggle Game GUI from Maker GUI

### DIFF
--- a/Stiletto.Core/Settings/DisplaySettings.cs
+++ b/Stiletto.Core/Settings/DisplaySettings.cs
@@ -38,6 +38,9 @@ namespace Stiletto.Settings
         public string Reload_Configurations { get; set; } = "Reload Configurations";
 
         [FileProperty]
+        public string Toggle_Game_Gui { get; set; } = "Manage Stiletto Settings";
+
+        [FileProperty]
         public string Active { get; set; } = "Active";
 
         [FileProperty]

--- a/Stiletto.Core/Stiletto.cs
+++ b/Stiletto.Core/Stiletto.cs
@@ -21,7 +21,7 @@ namespace Stiletto
         private StilettoGameGUI _gameWindow;
         private StilettoMakerGUI _makerWindow;
 
-        private ConfigEntry<KeyboardShortcut> _showWindowKey;
+        internal ConfigEntry<KeyboardShortcut> _showWindowKey;
         private bool _showWindow;
 
         private void Awake()
@@ -51,9 +51,14 @@ namespace Stiletto
         {
             if (_showWindowKey?.Value.IsDown() ?? false)
             {
-                _showWindow = !_showWindow;
-                _gameWindow.Show = _showWindow;
+                ToggleWindow();
             }
+        }
+
+        internal void ToggleWindow()
+        {
+            _showWindow = !_showWindow;
+            _gameWindow.Show = _showWindow;
         }
 
         [HarmonyPostfix, HarmonyPatch(typeof(OCIChar), nameof(OCIChar.ActiveKinematicMode))]

--- a/Stiletto.Core/StilettoMakerGUI.cs
+++ b/Stiletto.Core/StilettoMakerGUI.cs
@@ -32,6 +32,7 @@ namespace Stiletto
 
         private MakerButton button_HeelSave;
         private MakerButton button_Reload;
+        private MakerButton button_GameGui;
 
         private DisplaySettings displaySettings;
 
@@ -122,6 +123,13 @@ namespace Stiletto
 
             button_HeelSave = e.AddControl(new MakerButton(displaySettings.Save_Heel_Settings, category, plugin));
             button_Reload = e.AddControl(new MakerButton(displaySettings.Reload_Configurations, category, plugin));
+            // TODO: Maybe update the button label when the shortcut changes?
+            string suffix_GameGui = "";
+            if (plugin._showWindowKey != null)
+            {
+                suffix_GameGui = " (" + plugin._showWindowKey?.Value.Serialize() + ")";
+            }
+            button_GameGui = e.AddControl(new MakerButton(displaySettings.Toggle_Game_Gui + suffix_GameGui, category, plugin));
 
             slider_AnkleAngle.ValueChanged.Subscribe(value =>
                 MakerHeelInfoProcess(heel => heel.SafeProc(x => x.AnkleAngle = value))
@@ -172,6 +180,8 @@ namespace Stiletto
             ));
 
             button_Reload.OnClick.AddListener(StilettoContext.ReloadConfigurations);
+
+            button_GameGui.OnClick.AddListener(plugin.ToggleWindow);
         }
 
         public void OnHeelInfoUpdate(object _, HeelInfoEventArgs heelInfo)


### PR DESCRIPTION
Given that the default settings have Stiletto disabled for all poses, novice users may think that the Maker GUI is defective. Adding a GUI element that points them toward how to enable Stiletto should fix that UX issue.